### PR TITLE
Fix coverage CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           uv run ty check
       - name: Run the tests and gather coverage
         run: |
+          # Remove old coverage files
+          rm .coverage*
           uv run coverage run -m unittest discover
       - name: Coverage comment
         id: coverage_comment


### PR DESCRIPTION
Coverage fails because of implicit merge. Explicit merge won't work because one of the file detected as a coverage file is a license file.

Also, there's a committed `.coverage` file, it should not be committed.

The easiest way to get things working for now is to remove all `.coverage*` files before running.

This is likely not the cleanest fix, though.

Root cause: https://github.com/coveragepy/coveragepy/issues/2197
Linked to: https://github.com/py-cov-action/python-coverage-comment-action/issues/676